### PR TITLE
bump renv version

### DIFF
--- a/renv.lock
+++ b/renv.lock
@@ -1255,13 +1255,10 @@
     },
     "renv": {
       "Package": "renv",
-      "Version": "1.0.3",
-      "Source": "Repository",
+      "Version": "1.0.5",
+      "OS_type": null,
       "Repository": "CRAN",
-      "Requirements": [
-        "utils"
-      ],
-      "Hash": "41b847654f567341725473431dd0d5ab"
+      "Source": "Repository"
     },
     "reprex": {
       "Package": "reprex",

--- a/renv/profiles/R_422/renv.lock
+++ b/renv/profiles/R_422/renv.lock
@@ -1255,13 +1255,10 @@
     },
     "renv": {
       "Package": "renv",
-      "Version": "1.0.3",
-      "Source": "Repository",
+      "Version": "1.0.5",
+      "OS_type": null,
       "Repository": "CRAN",
-      "Requirements": [
-        "utils"
-      ],
-      "Hash": "41b847654f567341725473431dd0d5ab"
+      "Source": "Repository"
     },
     "reprex": {
       "Package": "reprex",

--- a/renv/profiles/R_431/renv.lock
+++ b/renv/profiles/R_431/renv.lock
@@ -1253,13 +1253,10 @@
     },
     "renv": {
       "Package": "renv",
-      "Version": "1.0.3",
-      "Source": "Repository",
+      "Version": "1.0.5",
+      "OS_type": null,
       "Repository": "CRAN",
-      "Requirements": [
-        "utils"
-      ],
-      "Hash": "41b847654f567341725473431dd0d5ab"
+      "Source": "Repository"
     },
     "reprex": {
       "Package": "reprex",


### PR DESCRIPTION
Bumping version in renv.lock files to reflect newest version of renv. I believe that users will get prompted to update renv when they load the project for the first time after pulling these changes.